### PR TITLE
Add 2018 CFP link

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -92,9 +92,15 @@
 
         <div class="col-xs-12 col-md-offset-2 col-md-8">
           <p style="margin-bottom: 2em;">
-            19 meetups web parisiens se réunissent pour vous proposer un Best Of de leurs talks de l'année, ainsi que quelques inédits
+            19 meetups web parisiens se réunissent pour vous proposer un Best Of de leurs talks de l'année, ainsi que beaucoup d'inédits
             et une journée de formation.
           </p>
+        </div>
+
+        <div class="col-xs-12 text-center meetups-cta" style="margin-top: 0;">
+          <a class="btn meetups-cta btn-cta" role="button" href="https://checkout.eventlama.com/#/events/best-of-web-2018/cfp" target="_blank">
+            <i class="fa fa-heart"></i>Proposez un talk pour Best Of Web 2018
+          </a>
         </div>
 
         <div class="col-sm-3 col-xs-6 meetups text-center">
@@ -215,7 +221,7 @@
 
         <div class="col-xs-12 text-center meetups-cta">
           <a class="btn meetups-cta btn-cta" role="button" href="/2017#schedule">
-            <i class="fa fa-video-camera"></i> Retrouvez les talks de Best of Web 2017
+            <i class="fa fa-video-camera"></i>Retrouvez les talks de Best of Web 2017
           </a>
         </div>
       </div>


### PR DESCRIPTION
Tried the heart icon, did not find a most relevant on on FontAwesome.
Put the button in an obvious position (before the meetup icons).
Added inline style :fearful: since this page will be changed in a few weeks.

